### PR TITLE
Add Basic Unit Testing to Project + Purge `setup.py`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,26 @@ permissions:
   contents: write  # needed to create GitHub Releases
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Requirements
+        run: |
+          pip install pygame pyglet
+
+      - name: Run Tests
+        run: python -m unittest discover -s tests/pytmx -p "test_*.py"
+
   build-and-release:
+    needs: test  # Waits for tests to pass
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+venv/

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-# encoding: utf-8
-# pip install wheel
-# python3 setup.py sdist bdist_wheel
-# python3 -m twine upload --repository pypi dist/*
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
PR introduces a simple test setup to help ensure our code behaves as expected. 

Here's what was added:
- `test` job in the GitHub Actions workflow
- uses Python’s built-in `unittest` framework to discover and run tests
- runs tests using Python 3.12
- includes `test_*.py` files as the naming convention
- installs required dependencies (`pygame`, `pyglet`) before running tests