### PR TITLE
Fix Incorrect Image Path Resolution for External Tilesets +  Fix Pyglet Demo

### DIFF
--- a/apps/pygame_sdl2_demo.py
+++ b/apps/pygame_sdl2_demo.py
@@ -28,7 +28,7 @@ class GameContext:
     renderer: Renderer
 
 
-class TiledRenderer(object):
+class TiledRenderer:
     """
     Super simple way to render a tiled map
     """

--- a/apps/pyglet_demo.py
+++ b/apps/pyglet_demo.py
@@ -25,8 +25,10 @@ from typing import Optional
 import pyglet
 from pyglet.sprite import Sprite
 
-from pytmx import *
-from pytmx.pytmx import ColorLike, PointLike
+from pytmx.constants import ColorLike, PointLike
+from pytmx.image_layer import TiledImageLayer
+from pytmx.object_group import TiledObjectGroup
+from pytmx.tile_layer import TiledTileLayer
 from pytmx.util_pyglet import load_pyglet
 
 

--- a/apps/pysdl2_demo.py
+++ b/apps/pysdl2_demo.py
@@ -37,7 +37,7 @@ from pytmx import *
 from pytmx.util_pysdl2 import load_pysdl2
 
 
-class TiledRenderer(object):
+class TiledRenderer:
     """
     Super simple way to render a tiled map with pyglet
 
@@ -82,7 +82,7 @@ class TiledRenderer(object):
                 self.render_tile_layer(layer)
 
 
-class SimpleTest(object):
+class SimpleTest:
     def __init__(self, filename, window) -> None:
         self.running = False
         self.dirty = False

--- a/pytmx/group_layer.py
+++ b/pytmx/group_layer.py
@@ -19,6 +19,7 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 Tiled group layer model and parser.
 """
 
+from typing import Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
@@ -36,17 +37,14 @@ class TiledGroupLayer(TiledElement):
         self.parent = parent
         self.name = None
         self.visible = 1
-        self._parse_xml(node)
+        self.parse_xml(node)
 
-    def _parse_xml(self, node: ElementTree.Element) -> "TiledGroupLayer":
+    def parse_xml(self, node: ElementTree.Element) -> Self:
         """
-        Parse a TiledGroup layer from ElementTree xml node.
-
-        Args:
-            node (ElementTree.Element): Node to parse.
+        Parse a TiledGroupLayer layer from ElementTree xml node.
 
         Returns:
-            TiledGroupLayer: The parsed TiledGroup layer.
+            TiledGroupLayer: The parsed TiledGroupLayer layer.
         """
         self._set_properties(node)
         self.name = node.get("name", None)

--- a/pytmx/image_layer.py
+++ b/pytmx/image_layer.py
@@ -17,6 +17,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from typing import Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
@@ -54,8 +55,13 @@ class TiledImageLayer(TiledElement):
             return self.parent.images[self.gid]
         return None
 
-    def parse_xml(self, node: ElementTree.Element):
-        """Parse an Image Layer from ElementTree xml node."""
+    def parse_xml(self, node: ElementTree.Element) -> Self:
+        """
+        Parse a TiledImageLayer layer from ElementTree xml node.
+
+        Returns:
+            TiledImageLayer: The parsed TiledImageLayer layer.
+        """
         self._set_properties(node)
         self.name = node.get("name", None)
         self.opacity = node.get("opacity", self.opacity)

--- a/pytmx/map.py
+++ b/pytmx/map.py
@@ -31,7 +31,7 @@ from collections.abc import Iterable
 from itertools import chain, product
 from logging import getLogger
 from operator import attrgetter
-from typing import Optional
+from typing import Optional, Self
 from xml.etree import ElementTree
 
 from .class_type import TiledClassType
@@ -181,11 +181,12 @@ class TiledMap(TiledElement):
 
                 self.custom_types[custom_type["name"]] = new
 
-    def parse_xml(self, node: ElementTree.Element) -> None:
-        """Parse a map from ElementTree xml node.
+    def parse_xml(self, node: ElementTree.Element) -> Self:
+        """
+        Parse a TiledMap layer from ElementTree xml node.
 
-        Args:
-            node (ElementTree.Element): ElementTree xml node to parse.
+        Returns:
+            TiledMap: The parsed TiledMap layer.
         """
         self._set_properties(node)
         self.background_color = node.get("backgroundcolor", None)

--- a/pytmx/object.py
+++ b/pytmx/object.py
@@ -19,6 +19,7 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 Tiled object model and parser.
 """
 
+from typing import Self
 from xml.etree import ElementTree
 
 from .constants import Point
@@ -66,14 +67,12 @@ class TiledObject(TiledElement):
             return self.parent.images[self.gid]
         return None
 
-    def parse_xml(self, node: ElementTree.Element) -> "TiledObject":
-        """Parse an Object from ElementTree xml node.
-
-        Args:
-            node (ElementTree.Element): The node to be parsed.
+    def parse_xml(self, node: ElementTree.Element) -> Self:
+        """
+        Parse a TiledObject layer from ElementTree xml node.
 
         Returns:
-            TiledObject: The parsed xml node.
+            TiledObject: The parsed TiledObject layer.
         """
 
         def read_points(text) -> tuple[tuple[float, float]]:

--- a/pytmx/object_group.py
+++ b/pytmx/object_group.py
@@ -50,13 +50,11 @@ class TiledObjectGroup(TiledElement, list):
         self.parse_xml(node)
 
     def parse_xml(self, node: ElementTree.Element) -> Self:
-        """Parse an Object Group from ElementTree xml node
-
-        Args:
-            node (ElementTree.Element): Node to parse.
+        """
+        Parse a TiledObjectGroup layer from ElementTree xml node.
 
         Returns:
-            TiledObjectGroup: The parsed object group.
+            TiledObjectGroup: The parsed TiledObjectGroup layer.
         """
         self._set_properties(node, self.custom_types)
         self.extend(

--- a/pytmx/property.py
+++ b/pytmx/property.py
@@ -19,6 +19,7 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 Tiled property model.
 """
 
+from typing import Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
@@ -37,5 +38,11 @@ class TiledProperty(TiledElement):
 
         self.parse_xml(node)
 
-    def parse_xml(self, node: ElementTree.Element) -> None:
+    def parse_xml(self, node: ElementTree.Element) -> Self:
+        """
+        Parse a TiledProperty layer from ElementTree xml node.
+
+        Returns:
+            TiledProperty: The parsed TiledProperty layer.
+        """
         pass

--- a/pytmx/tile_layer.py
+++ b/pytmx/tile_layer.py
@@ -20,7 +20,8 @@ Tiled tile layer model and parser.
 """
 
 import logging
-from typing import Iterable
+from collections.abc import Iterable
+from typing import Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
@@ -84,14 +85,12 @@ class TiledTileLayer(TiledElement):
         self.height = int(self.height)
         self.width = int(self.width)
 
-    def parse_xml(self, node: ElementTree.Element) -> "TiledTileLayer":
-        """Parse a Tile Layer from ElementTree xml node.
-
-        Args:
-            node (ElementTree.Element): Node to parse.
+    def parse_xml(self, node: ElementTree.Element) -> Self:
+        """
+        Parse a TiledTileLayer layer from ElementTree xml node.
 
         Returns:
-            TiledTileLayer: The parsed tile layer.
+            TiledTileLayer: The parsed TiledTileLayer layer.
         """
         self._set_properties(node)
         data_node = node.find("data")


### PR DESCRIPTION
PR addresses a bug that caused `pygame.image.load()` to fail with an "Unsupported image format" error when loading images from external `.tsx` tilesets. The issue was caused from incorrect path resolution logic introduced in a recent refactor.

Changes:
- added a new attribute `tileset_source` to store the path to the external `.tsx` file separately from the image source
- updated the `_resolve_path()` method to use `tileset_source` when resolving image paths relative to external tilesets
- prevented `self.source` from being overwritten during image node parsing, ensuring it only refers to the actual image file
- ensured that image paths are correctly resolved relative to the `.tsx` file, not the image itself, avoiding malformed paths like `tileset.png/tiles/grass.png`
- `pyglet_demo` has been fixed too (wrong imports)

This change restores compatibility with external tilesets and ensures that image files are correctly located and loaded by Pygame.