### PR TITLE
Refactor `TiledElement` with Abstract Base Class and Unit Tests

### DIFF
--- a/pytmx/group_layer.py
+++ b/pytmx/group_layer.py
@@ -19,14 +19,17 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 Tiled group layer model and parser.
 """
 
-from typing import Self
+from typing import TYPE_CHECKING, Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
 
+if TYPE_CHECKING:
+    from .map import TiledMap
+
 
 class TiledGroupLayer(TiledElement):
-    def __init__(self, parent, node: ElementTree.Element) -> None:
+    def __init__(self, parent: "TiledMap", node: ElementTree.Element) -> None:
         """
 
         Args:

--- a/pytmx/image_layer.py
+++ b/pytmx/image_layer.py
@@ -17,21 +17,23 @@ You should have received a copy of the GNU Lesser General Public
 License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
+
+if TYPE_CHECKING:
+    from .map import TiledMap
 
 
 class TiledImageLayer(TiledElement):
     """Represents Tiled Image Layer.
 
     The image associated with this layer will be loaded and assigned a GID.
-
     """
 
-    def __init__(self, parent, node: ElementTree.Element) -> None:
-        TiledElement.__init__(self)
+    def __init__(self, parent: "TiledMap", node: ElementTree.Element) -> None:
+        super().__init__()
         self.parent = parent
         self.source = None
         self.trans = None

--- a/pytmx/object.py
+++ b/pytmx/object.py
@@ -19,12 +19,15 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 Tiled object model and parser.
 """
 
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 from xml.etree import ElementTree
 
 from .constants import Point
 from .element import TiledElement
 from .utils import rotate
+
+if TYPE_CHECKING:
+    from .map import TiledMap
 
 
 class TiledObject(TiledElement):
@@ -34,8 +37,10 @@ class TiledObject(TiledElement):
     Supported types: Box, Ellipse, Tile Object, Polyline, Polygon, Text, Point.
     """
 
-    def __init__(self, parent, node, custom_types) -> None:
-        TiledElement.__init__(self)
+    def __init__(
+        self, parent: "TiledMap", node: ElementTree.Element, custom_types
+    ) -> None:
+        super().__init__()
         self.parent = parent
 
         # defaults from the specification

--- a/pytmx/object_group.py
+++ b/pytmx/object_group.py
@@ -19,22 +19,26 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 Object group model and parser.
 """
 
-from typing import Self
+from typing import TYPE_CHECKING, Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
 from .object import TiledObject
+
+if TYPE_CHECKING:
+    from .map import TiledMap
 
 
 class TiledObjectGroup(TiledElement, list):
     """Represents a Tiled ObjectGroup
 
     Supports any operation of a normal list.
-
     """
 
-    def __init__(self, parent, node, customs) -> None:
-        TiledElement.__init__(self)
+    def __init__(
+        self, parent: "TiledMap", node: ElementTree.Element, custom_types
+    ) -> None:
+        super().__init__()
         self.parent = parent
 
         # defaults from the specification
@@ -44,7 +48,7 @@ class TiledObjectGroup(TiledElement, list):
         self.visible = 1
         self.offsetx = 0
         self.offsety = 0
-        self.custom_types = customs
+        self.custom_types = custom_types
         self.draworder = "index"
 
         self.parse_xml(node)

--- a/pytmx/property.py
+++ b/pytmx/property.py
@@ -19,17 +19,20 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 Tiled property model.
 """
 
-from typing import Self
+from typing import TYPE_CHECKING, Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
+
+if TYPE_CHECKING:
+    from .map import TiledMap
 
 
 class TiledProperty(TiledElement):
     """Represents Tiled Property."""
 
-    def __init__(self, parent, node: ElementTree.Element) -> None:
-        TiledElement.__init__(self)
+    def __init__(self, parent: "TiledMap", node: ElementTree.Element) -> None:
+        super().__init__()
 
         # defaults from the specification
         self.name = None

--- a/pytmx/tile_layer.py
+++ b/pytmx/tile_layer.py
@@ -21,11 +21,14 @@ Tiled tile layer model and parser.
 
 import logging
 from collections.abc import Iterable
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
 from .utils import reshape_data, unpack_gids
+
+if TYPE_CHECKING:
+    from .map import TiledMap
 
 logger = logging.getLogger(__name__)
 
@@ -34,11 +37,10 @@ class TiledTileLayer(TiledElement):
     """Represents a TileLayer.
 
     To just get the tile images, use TiledTileLayer.tiles().
-
     """
 
-    def __init__(self, parent, node) -> None:
-        TiledElement.__init__(self)
+    def __init__(self, parent: "TiledMap", node: ElementTree.Element) -> None:
+        super().__init__()
         self.parent = parent
         self.data = list()
 
@@ -76,8 +78,8 @@ class TiledTileLayer(TiledElement):
         for x, y, gid in [i for i in self.iter_data() if i[2]]:
             yield x, y, images[gid]
 
-    def _set_properties(self, node) -> None:
-        TiledElement._set_properties(self, node)
+    def _set_properties(self, node: ElementTree.Element) -> None:
+        super()._set_properties(node)
 
         # TODO: make class/layer-specific type casting
         # layer height and width must be int, but TiledElement.set_properties()

--- a/pytmx/tileset.py
+++ b/pytmx/tileset.py
@@ -21,13 +21,17 @@ Tiled Tileset parser and model.
 
 import logging
 import os
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 from xml.etree import ElementTree
 from xml.etree.ElementTree import ParseError
+
 from .constants import AnimationFrame
 from .element import TiledElement
 from .object_group import TiledObjectGroup
 from .properties import parse_properties, types
+
+if TYPE_CHECKING:
+    from .map import TiledMap
 
 logger = logging.getLogger(__name__)
 
@@ -37,17 +41,16 @@ class TiledTileset(TiledElement):
 
     External tilesets are supported.  GID/ID's from Tiled are not
     guaranteed to be the same after loaded.
-
     """
 
-    def __init__(self, parent, node) -> None:
+    def __init__(self, parent: "TiledMap", node: ElementTree.Element) -> None:
         """Represents a Tiled Tileset
 
         Args:
             parent (???): ???.
             node (ElementTree.Element): ???.
         """
-        TiledElement.__init__(self)
+        super().__init__()
         self.parent = parent
         self.offset = (0, 0)
         self.tileset_source = None
@@ -92,7 +95,9 @@ class TiledTileset(TiledElement):
         logger.debug(f"Parsed tile properties: {props}")
         return props
 
-    def _parse_animation_frames(self, anim_node: ElementTree.Element) -> list[AnimationFrame]:
+    def _parse_animation_frames(
+        self, anim_node: ElementTree.Element
+    ) -> list[AnimationFrame]:
         """
         Parses animation frames from a tile's animation node.
         """

--- a/pytmx/util_pygame.py
+++ b/pytmx/util_pygame.py
@@ -126,7 +126,7 @@ def smart_convert(
     width, height = original.get_size()
     tile = None
 
-    def force_alpha():
+    def force_alpha() -> pygame.Surface:
         return original.convert_alpha()
 
     if colorkey:
@@ -292,7 +292,9 @@ def build_rects(
     elif isinstance(layer, str):
         try:
             # Find the layer with the matching name
-            layer_obj = next((l for l in tmxmap.layers if l.name and l.name == layer), None)
+            layer_obj = next(
+                (l for l in tmxmap.layers if l.name and l.name == layer), None
+            )
         except (AttributeError, TypeError) as e:
             msg = f"Error finding layer: {e}"
             logger.debug(msg)

--- a/pytmx/util_pyglet.py
+++ b/pytmx/util_pyglet.py
@@ -18,6 +18,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
+from pathlib import Path
 from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)

--- a/pytmx/util_pysdl2.py
+++ b/pytmx/util_pysdl2.py
@@ -55,7 +55,10 @@ def pysdl2_image_loader(
         sdl2.SDL_FreeSurface(surface)
         return texture_
 
-    def load_image(rect: Optional[tuple[int, int, int, int]] = None, flags: Optional[TileFlags] = None) -> Any:
+    def load_image(
+        rect: Optional[tuple[int, int, int, int]] = None,
+        flags: Optional[TileFlags] = None,
+    ) -> Any:
         if rect:
             try:
                 flip = 0
@@ -87,6 +90,8 @@ def pysdl2_image_loader(
     return load_image
 
 
-def load_pysdl2(renderer: sdl2.SDL_Renderer, filename: str, *args: Any, **kwargs: Any) -> TiledMap:
+def load_pysdl2(
+    renderer: sdl2.SDL_Renderer, filename: str, *args: Any, **kwargs: Any
+) -> TiledMap:
     kwargs["image_loader"] = partial(pysdl2_image_loader, renderer)
     return TiledMap(filename, *args, **kwargs)

--- a/pytmx/utils.py
+++ b/pytmx/utils.py
@@ -24,14 +24,14 @@ classes and can be reused across the package.
 
 from __future__ import annotations
 
+import gzip
+import struct
+import zlib
 from base64 import b64decode
 from collections.abc import Sequence
-import gzip
 from logging import getLogger
 from math import cos, radians, sin
-import struct
 from typing import Optional, Union
-import zlib
 
 logger = getLogger(__name__)
 

--- a/tests/pytmx/test_element.py
+++ b/tests/pytmx/test_element.py
@@ -1,0 +1,193 @@
+import unittest
+from unittest.mock import patch
+from xml.etree.ElementTree import Element
+
+from pytmx.element import TiledElement
+from pytmx.properties import parse_properties
+
+
+class DummyElement(TiledElement):
+    def __init__(self, allow_duplicate_names=False):
+        super().__init__(allow_duplicate_names=allow_duplicate_names)
+
+    def parse_xml(self, node):
+        self._set_properties(node)
+        return self
+
+
+class CustomClass(TiledElement):
+    def __init__(self):
+        super().__init__()
+        self.properties["foo"] = "bar"
+
+    def parse_xml(self, node):
+        self._set_properties(node)
+        return self
+
+
+class TestTiledElement(unittest.TestCase):
+
+    def setUp(self):
+        self.element = DummyElement()
+
+    def test_initial_state(self):
+        self.assertFalse(self.element._allow_duplicate_names)
+        self.assertEqual(self.element.properties, {})
+
+    def test_cast_and_set_attributes(self):
+        items = [("width", "32"), ("height", "64"), ("visible", "1")]
+        self.element._cast_and_set_attributes_from_node_items(items)
+        self.assertEqual(self.element.width, 32.0)
+        self.assertEqual(self.element.height, 64.0)
+        self.assertTrue(self.element.visible)
+
+    def test_invalid_property_name_detection(self):
+        self.element.name = "TestElement"
+        items = [("name", "conflict")]
+        self.assertTrue(self.element._contains_invalid_property_name(items))
+
+    def test_valid_property_name_with_duplicates_allowed(self):
+        self.element.allow_duplicate_names = True
+        items = [("name", "conflict")]
+        self.assertFalse(self.element._contains_invalid_property_name(items))
+
+    def test_set_properties_with_valid_data(self):
+        xml = Element("element", attrib={"width": "128", "height": "256"})
+        props = Element("properties")
+        prop = Element("property", attrib={"name": "custom", "value": "hello"})
+        props.append(prop)
+        xml.append(props)
+
+        self.element._set_properties(xml)
+        self.assertEqual(self.element.width, 128.0)
+        self.assertEqual(self.element.height, 256.0)
+        self.assertEqual(self.element.properties["custom"], "hello")
+
+    def test_set_properties_with_conflict_raises(self):
+        xml = Element("element", attrib={"name": "conflict"})
+        props = Element("properties")
+        prop = Element("property", attrib={"name": "name", "value": "oops"})
+        props.append(prop)
+        xml.append(props)
+
+        with self.assertRaises(ValueError):
+            self.element._set_properties(xml)
+
+    def test_getattr_existing_property(self):
+        self.element.properties["foo"] = "bar"
+        self.assertEqual(self.element.foo, "bar")
+
+    def test_getattr_missing_property_with_name(self):
+        self.element.properties["name"] = "TestElement"
+        with self.assertRaises(AttributeError) as cm:
+            _ = self.element.missing
+        self.assertIn("TestElement", str(cm.exception))
+
+    def test_getattr_missing_property_without_name(self):
+        with self.assertRaises(AttributeError) as cm:
+            _ = self.element.missing
+        self.assertIn("Element has no property", str(cm.exception))
+
+    def test_repr_with_id(self):
+        self.element.id = 42
+        self.element.name = "MyElement"
+        self.assertEqual(repr(self.element), '<DummyElement[42]: "MyElement">')
+
+    def test_repr_without_id(self):
+        self.element.name = "MyElement"
+        self.assertEqual(repr(self.element), '<DummyElement: "MyElement">')
+
+    def test_from_xml_string(self):
+        xml = """
+        <element width="100" height="200">
+            <properties>
+                <property name="custom" value="value" />
+            </properties>
+        </element>
+        """
+        obj = DummyElement.from_xml_string(xml)
+        self.assertEqual(obj.width, 100.0)
+        self.assertEqual(obj.height, 200.0)
+        self.assertEqual(obj.properties["custom"], "value")
+
+    def test_property_type_casting(self):
+        xml = Element("element")
+        props = Element("properties")
+        prop = Element(
+            "property", attrib={"name": "visible", "type": "bool", "value": "true"}
+        )
+        props.append(prop)
+        xml.append(props)
+
+        props_dict = parse_properties(xml)
+        self.assertTrue(props_dict["visible"])
+
+    @patch("pytmx.properties.deepcopy", lambda x: x)
+    def test_nested_class_property(self):
+        customs = {"MyClass": CustomClass()}
+        xml = Element("element")
+        props = Element("properties")
+        class_prop = Element(
+            "property",
+            attrib={"name": "nested", "type": "class", "propertytype": "MyClass"},
+        )
+        subprop = Element("property", attrib={"name": "foo", "value": "bar"})
+        class_prop.append(subprop)
+        props.append(class_prop)
+        xml.append(props)
+
+        props_dict = parse_properties(xml, customs)
+        self.assertEqual(props_dict["nested"].foo, "bar")
+
+    def test_property_fallback_to_text(self):
+        xml = Element("element")
+        props = Element("properties")
+        prop = Element("property", attrib={"name": "fallback"})
+        prop.text = "fallback_value"
+        props.append(prop)
+        xml.append(props)
+
+        props_dict = parse_properties(xml)
+        self.assertEqual(props_dict["fallback"], "fallback_value")
+
+    def test_property_type_not_found_logs_info(self):
+        xml = Element("element")
+        props = Element("properties")
+        prop = Element(
+            "property", attrib={"name": "unknown", "type": "mystery", "value": "42"}
+        )
+        props.append(prop)
+        xml.append(props)
+
+        props_dict = parse_properties(xml)
+        self.assertEqual(props_dict["unknown"], "42")
+
+    def test_parse_xml_sets_properties(self):
+        xml = Element("element", attrib={"width": "100", "height": "200"})
+        props = Element("properties")
+        prop = Element("property", attrib={"name": "custom", "value": "hello"})
+        props.append(prop)
+        xml.append(props)
+
+        result = self.element.parse_xml(xml)
+        self.assertEqual(result.width, 100.0)
+        self.assertEqual(result.height, 200.0)
+        self.assertEqual(result.properties["custom"], "hello")
+
+    def test_repr_output(self):
+        self.element.id = 1
+        self.element.name = "TestDummy"
+        self.assertEqual(repr(self.element), '<DummyElement[1]: "TestDummy">')
+
+    def test_property_access(self):
+        self.element.properties["foo"] = "bar"
+        self.assertEqual(self.element.foo, "bar")
+
+    def test_missing_property_raises(self):
+        with self.assertRaises(AttributeError):
+            _ = self.element.nonexistent
+
+    def test_contains_invalid_property_name(self):
+        self.element.name = "dummy"
+        items = [("name", "conflict")]
+        self.assertTrue(self.element._contains_invalid_property_name(items))

--- a/tests/pytmx/test_pytmx.py
+++ b/tests/pytmx/test_pytmx.py
@@ -110,9 +110,9 @@ class TiledMapTest(unittest.TestCase):
         self.assertIsNotNone(image)
 
     def test_reserved_names_check_disabled_with_option(self) -> None:
-        TiledElement.allow_duplicate_names = False
-        TiledMap(allow_duplicate_names=True)
-        self.assertTrue(TiledElement.allow_duplicate_names)
+        tiled_map = TiledMap(allow_duplicate_names=True)
+        items = [("name", "conflict")]
+        self.assertFalse(tiled_map._contains_invalid_property_name(items))
 
     def test_map_width_height_is_int(self) -> None:
         self.assertIsInstance(self.m.width, int)
@@ -139,53 +139,3 @@ class TiledMapTest(unittest.TestCase):
         self.assertEqual(self.m.pixels_to_tile_pos((33, 0)), (2, 0))
         self.assertEqual(self.m.pixels_to_tile_pos((0, 0)), (0, 0))
         self.assertEqual(self.m.pixels_to_tile_pos((65, 86)), (4, 5))
-
-
-class TiledElementTestCase(unittest.TestCase):
-    def setUp(self) -> None:
-        self.element = TiledElement()
-
-    def test_from_xml_string_should_raise_on_TiledElement(self) -> None:
-        with self.assertRaises(AttributeError):
-            TiledElement.from_xml_string("<element></element>")
-
-    def test_contains_reserved_property_name(self) -> None:
-        """Reserved names are checked from any attributes in the instance
-        after it is created.  Instance attributes are defaults from the
-        specification.  We check that new properties are not named same
-        as existing attributes.
-        """
-        logging.disable(logging.CRITICAL)  # disable logging
-        self.element.name = "foo"
-        items = {"name": None}
-        result = self.element._contains_invalid_property_name(items.items())
-        self.assertTrue(result)
-        logging.disable(logging.NOTSET)  # reset logging
-
-    def test_not_contains_reserved_property_name(self) -> None:
-        """Reserved names are checked from any attributes in the instance
-        after it is created.  Instance attributes are defaults from the
-        specification.  We check that new properties are not named same
-        as existing attributes.
-        """
-        items = {"name": None}
-        result = self.element._contains_invalid_property_name(items.items())
-        self.assertFalse(result)
-
-    def test_reserved_names_check_disabled_with_option(self) -> None:
-        """Reserved names are checked from any attributes in the instance
-        after it is created.  Instance attributes are defaults from the
-        specification.  We check that new properties are not named same
-        as existing attributes.
-
-        Check that passing an option will disable the check
-        """
-        TiledElement.allow_duplicate_names = True
-        self.element.name = "foo"
-        items = {"name": None}
-        result = self.element._contains_invalid_property_name(items.items())
-        self.assertFalse(result)
-
-    def test_repr(self) -> None:
-        self.element.name = "foo"
-        self.assertEqual('<TiledElement: "foo">', self.element.__repr__())


### PR DESCRIPTION
PR improves the design and reliability of the `TiledElement` base class and its usage across the codebase.

Here's what was changed:
- converted `TiledElement` into an abstract base class using `ABC`
- added an abstract method `parse_xml()` to make it clear that all subclasses must implement it
- replaced all direct calls to `TiledElement.__init__()` in subclasses with `super().__init__()` for proper inheritance
- added a complete and dedicated `unittest` suite for `TiledElement` and its subclasses
- moved related tests from `test_pytmx.py` into the new test file to keep things organized
- added back `from pathlib import Path` to `util_pyglet`, it was removed, but without it, well, it doesn't work
- fixed some typing
- previously, `allow_duplicate_names` was defined as a class-level variable in `TiledElement`, meaning its value was shared across all instances, this design introduced subtle bugs and test leakage, since changing the flag in one part of the code could unintentionally affect other objects elsewhere, so to resolve this, I refactored the flag into an instance-level attribute, ensuring that each object maintains its own configuration independently. This change improves encapsulation, eliminates shared mutable state and makes the behavior of each `TiledElement` more predictable and testable

The original design had some serious problems:
- it violated the Liskov Principle, because `from_xml_string()` calls `parse_xml()`, but `TiledElement` doesn’t define it, and this means you can’t use a subclass in place of the base class without risking a crash
- no clarity, there was no clear signal that subclasses must implement `parse_xml()`

this update fixes those issues by enforcing the contract at the class level and adding proper tests to catch problems early.