### PR TITLE
Refactor `TiledTileset` XML Parsing

### DIFF
--- a/apps/benchmark.py
+++ b/apps/benchmark.py
@@ -15,12 +15,8 @@ Missing interactive_tests:
 - terrains
 """
 
-import os
-
-# os.environ["SDL_VIDEODRIVER"] = "dummy"
-# os.environ["SDL_AUDIODRIVER"] = "dummy"
-
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -31,6 +27,10 @@ from pytmx.image_layer import TiledImageLayer
 from pytmx.layer import TiledTileLayer
 from pytmx.object_group import TiledObjectGroup
 from pytmx.util_pygame import load_pygame
+
+# os.environ["SDL_VIDEODRIVER"] = "dummy"
+# os.environ["SDL_AUDIODRIVER"] = "dummy"
+
 
 # Logging setup
 logging.basicConfig(

--- a/pytmx/map.py
+++ b/pytmx/map.py
@@ -35,7 +35,6 @@ from operator import attrgetter
 from typing import Any, Iterator, Optional, Self
 from xml.etree import ElementTree
 
-
 # --- internal imports -------------------------------------------------------
 from .class_type import TiledClassType
 from .constants import GID_TRANS_ROT, MapPoint, TileFlags
@@ -462,7 +461,6 @@ class TiledMap(TiledElement):
             msg = f"Tile coordinates and layers must be non-negative, were ({x}, {y}), layer={target_layer}"
             logger.error(msg)
             raise ValueError(msg)
-            
 
         try:
             layer = self.layers[target_layer]
@@ -506,7 +504,9 @@ class TiledMap(TiledElement):
         gid = self.get_tile_gid(x, y, layer)
         return self.get_tile_properties_by_gid(gid)
 
-    def get_tile_locations_by_gid(self, gid: int, only_visible: bool = True) -> Iterable[MapPoint]:
+    def get_tile_locations_by_gid(
+        self, gid: int, only_visible: bool = True
+    ) -> Iterable[MapPoint]:
         """Search map for tile locations by the GID.
 
         Note: Not a fast operation.  Cache results if used often.

--- a/pytmx/object.py
+++ b/pytmx/object.py
@@ -38,7 +38,10 @@ class TiledObject(TiledElement):
     """
 
     def __init__(
-        self, parent: "TiledMap", node: ElementTree.Element, custom_types: dict[str, Any]
+        self,
+        parent: "TiledMap",
+        node: ElementTree.Element,
+        custom_types: dict[str, Any],
     ) -> None:
         super().__init__()
         self.parent = parent


### PR DESCRIPTION
PR refactors the `TiledTileset` class.
No functional behavior has changed, but the code is now easier to follow.

Changes:
- extracted external tileset handling into a new method `_handle_external_source()`, simplifies `parse_xml()` and isolates logic for loading `.tsx` files
- moved tile parsing logic** into `_parse_all_tiles()`, makes the main parsing flow cleaner and separates concerns
- isolated image and offset parsing** into `_parse_tileset_image_and_offset()`, improves readability and avoids clutter in `parse_xml()`
- preserved original behavior
- enhanced debug logging