### PR TITLE
Refactor `TiledObjectGroup` to Use Internal List

### DIFF
--- a/apps/benchmark.py
+++ b/apps/benchmark.py
@@ -15,12 +15,8 @@ Missing interactive_tests:
 - terrains
 """
 
-import os
-
-# os.environ["SDL_VIDEODRIVER"] = "dummy"
-# os.environ["SDL_AUDIODRIVER"] = "dummy"
-
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -31,6 +27,10 @@ from pytmx.image_layer import TiledImageLayer
 from pytmx.layer import TiledTileLayer
 from pytmx.object_group import TiledObjectGroup
 from pytmx.util_pygame import load_pygame
+
+# os.environ["SDL_VIDEODRIVER"] = "dummy"
+# os.environ["SDL_AUDIODRIVER"] = "dummy"
+
 
 # Logging setup
 logging.basicConfig(

--- a/pytmx/map.py
+++ b/pytmx/map.py
@@ -35,7 +35,6 @@ from operator import attrgetter
 from typing import Any, Iterator, Optional, Self
 from xml.etree import ElementTree
 
-
 # --- internal imports -------------------------------------------------------
 from .class_type import TiledClassType
 from .constants import GID_TRANS_ROT, MapPoint, TileFlags
@@ -462,7 +461,6 @@ class TiledMap(TiledElement):
             msg = f"Tile coordinates and layers must be non-negative, were ({x}, {y}), layer={target_layer}"
             logger.error(msg)
             raise ValueError(msg)
-            
 
         try:
             layer = self.layers[target_layer]
@@ -506,7 +504,9 @@ class TiledMap(TiledElement):
         gid = self.get_tile_gid(x, y, layer)
         return self.get_tile_properties_by_gid(gid)
 
-    def get_tile_locations_by_gid(self, gid: int, only_visible: bool = True) -> Iterable[MapPoint]:
+    def get_tile_locations_by_gid(
+        self, gid: int, only_visible: bool = True
+    ) -> Iterable[MapPoint]:
         """Search map for tile locations by the GID.
 
         Note: Not a fast operation.  Cache results if used often.

--- a/pytmx/object.py
+++ b/pytmx/object.py
@@ -38,7 +38,10 @@ class TiledObject(TiledElement):
     """
 
     def __init__(
-        self, parent: "TiledMap", node: ElementTree.Element, custom_types: dict[str, Any]
+        self,
+        parent: "TiledMap",
+        node: ElementTree.Element,
+        custom_types: dict[str, Any],
     ) -> None:
         super().__init__()
         self.parent = parent

--- a/pytmx/object_group.py
+++ b/pytmx/object_group.py
@@ -19,7 +19,8 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 Object group model and parser.
 """
 
-from typing import TYPE_CHECKING, Self
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Optional, Self, Union
 from xml.etree import ElementTree
 
 from .element import TiledElement
@@ -29,17 +30,21 @@ if TYPE_CHECKING:
     from .map import TiledMap
 
 
-class TiledObjectGroup(TiledElement, list):
-    """Represents a Tiled ObjectGroup
-
-    Supports any operation of a normal list.
+class TiledObjectGroup(TiledElement):
+    """
+    Represents a Tiled ObjectGroup, acting as a container (list) for TiledObjects.
     """
 
     def __init__(
-        self, parent: "TiledMap", node: ElementTree.Element, custom_types
+        self,
+        parent: "TiledMap",
+        node: ElementTree.Element,
+        custom_types: Optional[dict[str, Any]] = None,
     ) -> None:
         super().__init__()
         self.parent = parent
+
+        self._objects: list[TiledObject] = []
 
         # defaults from the specification
         self.name = None
@@ -61,9 +66,42 @@ class TiledObjectGroup(TiledElement, list):
             TiledObjectGroup: The parsed TiledObjectGroup layer.
         """
         self._set_properties(node, self.custom_types)
-        self.extend(
+
+        self._objects.extend(
             TiledObject(self.parent, child, self.custom_types)
             for child in node.findall("object")
         )
 
         return self
+
+    def __len__(self) -> int:
+        """Returns the number of objects in the group."""
+        return len(self._objects)
+
+    def __iter__(self) -> Iterator[TiledObject]:
+        """Allows iteration (e.g., for obj in group:)."""
+        return iter(self._objects)
+
+    def __getitem__(
+        self, index: Union[int, slice]
+    ) -> Union[TiledObject, list[TiledObject]]:
+        """Allows indexing and slicing (e.g., group[0], group[2:5])."""
+        return self._objects[index]
+
+    def append(self, obj: TiledObject) -> None:
+        self._objects.append(obj)
+
+    def remove(self, obj: TiledObject) -> None:
+        """Remove a specific object from the group."""
+        self._objects.remove(obj)
+
+    def clear(self) -> None:
+        """Remove all objects from the group."""
+        self._objects.clear()
+
+    def find_by_name(self, name: str) -> Optional[TiledObject]:
+        """Find the first object with a matching name."""
+        for obj in self._objects:
+            if getattr(obj, "name", None) == name:
+                return obj
+        return None


### PR DESCRIPTION
PR improves the `TiledObjectGroup` class,

Changes:
- removed inheritance from `list` and replaced it with an internal list `_objects` to manage contained `TiledObject` instances
- implemented standard container methods: `__len__`, `__iter__`, and `__getitem__` to preserve list-like behavior
- Introduced 3 new methods: `remove(obj)` which removes a specific object from the group, `clear()` which clears all objects from the group and `find_by_name(name)` which returns the first object with a matching name, or `None` if not found

Unrelated quick question: does `allow_duplicate_names` apply just to objects, or does it cover layers too? And if layers are included, should we be adding a check for that inside `add_layer`?

```
    # Check for duplicate names if not allowed
    if not self.allow_duplicate_names and layer.name in self.layernames:
        msg = f"A layer with the name '{layer.name}' already exists. Duplicate names are not allowed."
        logger.error(msg)
        raise ValueError(msg)
```