### PR TITLE
Improve Type Safety via `mypy --strict` Compliance

### DIFF
--- a/pytmx/element.py
+++ b/pytmx/element.py
@@ -42,7 +42,7 @@ class TiledElement(ABC):
                 to have the same name as class attributes.
         """
         self._allow_duplicate_names = allow_duplicate_names
-        self.properties = dict()
+        self.properties: dict[str, Any] = dict()
 
     @classmethod
     def from_xml_string(cls, xml_string: str) -> Self:

--- a/pytmx/group_layer.py
+++ b/pytmx/group_layer.py
@@ -19,7 +19,7 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 Tiled group layer model and parser.
 """
 
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Optional, Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
@@ -38,8 +38,8 @@ class TiledGroupLayer(TiledElement):
         """
         super().__init__()
         self.parent = parent
-        self.name = None
-        self.visible = 1
+        self.name: Optional[str] = None
+        self.visible: bool = True
         self.parse_xml(node)
 
     def parse_xml(self, node: ElementTree.Element) -> Self:
@@ -50,5 +50,5 @@ class TiledGroupLayer(TiledElement):
             TiledGroupLayer: The parsed TiledGroupLayer layer.
         """
         self._set_properties(node)
-        self.name = node.get("name", None)
+        self.name = node.get("name") or ""
         return self

--- a/pytmx/image_layer.py
+++ b/pytmx/image_layer.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Optional, Self
 from xml.etree import ElementTree
 
 from .element import TiledElement
@@ -35,14 +35,14 @@ class TiledImageLayer(TiledElement):
     def __init__(self, parent: "TiledMap", node: ElementTree.Element) -> None:
         super().__init__()
         self.parent = parent
-        self.source = None
-        self.trans = None
-        self.gid = 0
+        self.source: Optional[str] = None
+        self.trans: Optional[str] = None
+        self.gid: int = 0
 
         # defaults from the specification
-        self.name = None
-        self.opacity = 1
-        self.visible = 1
+        self.name: Optional[str] = None
+        self.opacity: float = 1.0
+        self.visible: bool = True
 
         self.parse_xml(node)
 
@@ -65,10 +65,14 @@ class TiledImageLayer(TiledElement):
             TiledImageLayer: The parsed TiledImageLayer layer.
         """
         self._set_properties(node)
-        self.name = node.get("name", None)
-        self.opacity = node.get("opacity", self.opacity)
-        self.visible = node.get("visible", self.visible)
+
+        self.name = node.get("name")
+        self.opacity = float(node.get("opacity", self.opacity))
+        self.visible = bool(int(node.get("visible", int(self.visible))))
+
         image_node = node.find("image")
-        self.source = image_node.get("source", None)
-        self.trans = image_node.get("trans", None)
+        if image_node is not None:
+            self.source = image_node.get("source")
+            self.trans = image_node.get("trans")
+
         return self

--- a/pytmx/object_group.py
+++ b/pytmx/object_group.py
@@ -47,14 +47,14 @@ class TiledObjectGroup(TiledElement):
         self._objects: list[TiledObject] = []
 
         # defaults from the specification
-        self.name = None
-        self.color = None
-        self.opacity = 1
-        self.visible = 1
-        self.offsetx = 0
-        self.offsety = 0
+        self.name: Optional[str] = None
+        self.color: Optional[str] = None
+        self.opacity: float = 1.0
+        self.visible: bool = True
+        self.offsetx: int = 0
+        self.offsety: int = 0
         self.custom_types = custom_types
-        self.draworder = "index"
+        self.draworder: str = "index"
 
         self.parse_xml(node)
 
@@ -68,7 +68,7 @@ class TiledObjectGroup(TiledElement):
         self._set_properties(node, self.custom_types)
 
         self._objects.extend(
-            TiledObject(self.parent, child, self.custom_types)
+            TiledObject(self.parent, child, self.custom_types or {})
             for child in node.findall("object")
         )
 

--- a/pytmx/property.py
+++ b/pytmx/property.py
@@ -48,4 +48,4 @@ class TiledProperty(TiledElement):
         Returns:
             TiledProperty: The parsed TiledProperty layer.
         """
-        pass
+        return self

--- a/pytmx/util_pygame_sdl2.py
+++ b/pytmx/util_pygame_sdl2.py
@@ -81,11 +81,11 @@ def pygame_sd2_image_loader(
     if colorkey:
         if isinstance(colorkey, str):
             if not colorkey.startswith("#") and len(colorkey) in (6, 8):
-                colorkey = pygame.Color(f"#{colorkey}")
+                colorkey = tuple(pygame.Color(f"#{colorkey}"))[:3]  # type: ignore
             else:
-                colorkey = pygame.Color(colorkey)
+                colorkey = tuple(pygame.Color(colorkey))[:3]  # type: ignore
         elif isinstance(colorkey, tuple) and 3 <= len(colorkey) <= 4:
-            colorkey = pygame.Color(colorkey)
+            colorkey = tuple(pygame.Color(colorkey))[:3]  # type: ignore
         else:
             logger.error("Invalid colorkey")
             raise ValueError("Invalid colorkey")

--- a/pytmx/util_pyglet.py
+++ b/pytmx/util_pyglet.py
@@ -24,7 +24,7 @@ from typing import Any, Callable, Optional
 logger = logging.getLogger(__name__)
 
 try:
-    import pyglet
+    import pyglet  # type: ignore
 except ImportError:
     logger.error("cannot import pyglet (is it installed?)")
     raise
@@ -104,7 +104,7 @@ def handle_flags(flags: Optional[TileFlags]) -> tuple[float, bool, bool]:
     return 0.0, flipped_h, flipped_v
 
 
-def load_pyglet(filename: str, *args: Any, **kwargs) -> TiledMap:
+def load_pyglet(filename: str, *args: Any, **kwargs: Any) -> TiledMap:
     kwargs["image_loader"] = pyglet_image_loader
     kwargs["invert_y"] = True
     return TiledMap(filename, *args, **kwargs)


### PR DESCRIPTION
PR improves type annotations across the codebase based on results from running `mypy --strict`. It resolves numerous typing issues, reducing the total number of reported errors to below 10.


I was unsure about this
```
    def add_layer(
        self,
        layer: TiledLayer,
    ) -> None:
        assert isinstance(
            layer, (TiledGroupLayer, TiledTileLayer, TiledImageLayer, TiledObjectGroup)
        )

        self.layers.append(layer)
        if layer.name is None:
            logger.warning("Layer has no name; assigning default.")
            layer.name = f"layer_{len(self.layernames)}"

        self.layernames[layer.name] = layer
```
is it ok? do we need to skip it?
```
if layer.name is not None:
    self.layernames[layer.name] = layer
```
