### PR TITLE
Improvements_hopefully

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,19 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Validate tag matches pyproject version
+      - name: Install setuptools-scm for version check
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools-scm
+
+      - name: Validate tag matches setuptools-scm version
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           echo "Git tag version: $TAG_VERSION"
-          PYPROJECT_VERSION=$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])")
-          echo "pyproject version: $PYPROJECT_VERSION"
-          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
-            echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml version ($PYPROJECT_VERSION)."
+          SCM_VERSION=$(python -c "from setuptools_scm import get_version; print(get_version())")
+          echo "setuptools-scm version: $SCM_VERSION"
+          if [ "$TAG_VERSION" != "$SCM_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match setuptools-scm version ($SCM_VERSION)."
             exit 1
           fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytmx-ng"
-version = "3.35.0"
+dynamic = ["version"]
 description = "Loads tiled tmx maps"
 readme = {file = "readme.md", content-type = "text/markdown"}
 license = {text = "LGPL-3.0-or-later"}
@@ -36,6 +36,8 @@ Issues = "https://github.com/pnearing/pytmx-ng/issues"
 
 [tool.setuptools]
 packages = ["pytmx"]
+
+[tool.setuptools_scm]
 
 [project.optional-dependencies]
 pygame = ["pygame>=2.0.0"]

--- a/pytmx/__init__.py
+++ b/pytmx/__init__.py
@@ -18,6 +18,7 @@ License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import logging
+from importlib.metadata import PackageNotFoundError, version
 
 from .pytmx import *
 
@@ -28,4 +29,9 @@ try:
 except ImportError:
     logger.debug("cannot import pygame tools")
 
-__version__ = (3, 32)
+# Expose the installed package version. When running from a source checkout
+# without installed metadata, fall back to a sentinel string.
+try:
+    __version__ = version("pytmx-ng")
+except PackageNotFoundError:
+    __version__ = "0+unknown"


### PR DESCRIPTION
Version mismatch & duplication
pyproject.toml sets version = "3.35.0" while pytmx/__init__.py defines __version__ = (3, 32). Pick one source of truth.
Fix: Use setuptools-scm (already listed) and make version dynamic. Remove the hardcoded tuple and expose __version__ = importlib.metadata.version("pytmx-ng").