### PR TITLE
Add Collider dataclass and support for tile-level collision shapes in TiledTileset

### DIFF
--- a/apps/data/tiles_spritesheet.tsx
+++ b/apps/data/tiles_spritesheet.tsx
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tileset name="tiles_spritesheet" tilewidth="70" tileheight="70" spacing="2">
+<tileset version="1.8" tiledversion="1.8.2" name="tiles_spritesheet" tilewidth="70" tileheight="70" spacing="2" tilecount="156" columns="12">
  <image source="tiles_spritesheet.png" width="914" height="936"/>
+ <tile id="54">
+  <objectgroup draworder="index" id="2">
+   <object id="1" x="24.2552" y="20.3964" width="25.3577" height="29.7677"/>
+  </objectgroup>
+ </tile>
 </tileset>

--- a/apps/pygame_demo.py
+++ b/apps/pygame_demo.py
@@ -167,8 +167,17 @@ class SimpleTest:
             logger.info("%s\t%s", k, v)
 
         logger.info("Tile colliders:")
-        for k, v in self.renderer.tmx_data.get_tile_colliders():
-            logger.info("%s\t%s", k, list(v))
+        for k, colliders in self.renderer.tmx_data.get_tile_colliders():
+            if colliders:
+                logger.info(f"  GID {k}:")
+                for collider in colliders:
+                    center_x, center_y = collider.get_center()
+                    logger.info(
+                        "    - Type: %s, Center: (%d, %d)",
+                        collider.type,
+                        center_x,
+                        center_y,
+                    )
 
     def draw(self, surface: pygame.Surface) -> None:
         """Draw our map to some surface (probably the display)"""

--- a/apps/pygame_sdl2_demo.py
+++ b/apps/pygame_sdl2_demo.py
@@ -111,8 +111,17 @@ class SimpleTest:
             logger.info("%s\t%s", k, v)
 
         logger.info("Tile colliders:")
-        for k, v in self.map_renderer.tmx_data.get_tile_colliders():
-            logger.info("%s\t%s", k, list(v))
+        for k, colliders in self.map_renderer.tmx_data.get_tile_colliders():
+            if colliders:
+                logger.info(f"  GID {k}:")
+                for collider in colliders:
+                    center_x, center_y = collider.get_center()
+                    logger.info(
+                        "    - Type: %s, Center: (%d, %d)",
+                        collider.type,
+                        center_x,
+                        center_y,
+                    )
 
     def draw(self) -> None:
         """

--- a/pytmx/collider.py
+++ b/pytmx/collider.py
@@ -1,0 +1,56 @@
+"""
+Copyright (C) 2012-2025, Leif Theden <leif.theden@gmail.com>
+
+This file is part of pytmx.
+
+pytmx is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+pytmx is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from .constants import Point
+from .utils import rotate
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Collider:
+    x: float
+    y: float
+    width: float = 0.0
+    height: float = 0.0
+    type: str = "rectangle"  # rectangle, polygon, ellipse, point
+    rotation: float = 0.0
+    points: Optional[list[tuple[float, float]]] = None
+    properties: dict[str, Any] = field(default_factory=dict)
+
+    def get_center(self) -> tuple[float, float]:
+        """Return the center point of the collider."""
+        return self.x + self.width / 2, self.y + self.height / 2
+
+    def get_property(self, key: str, default: Any = None) -> Any:
+        """Safely retrieve a custom property with an optional default value."""
+        return self.properties.get(key, default)
+
+    def is_polygon(self) -> bool:
+        return self.type == "polygon"
+
+    def is_ellipse(self) -> bool:
+        return self.type == "ellipse"
+
+    def is_point(self) -> bool:
+        return self.type == "point"

--- a/tests/pytmx/test_collider.py
+++ b/tests/pytmx/test_collider.py
@@ -1,0 +1,35 @@
+import unittest
+
+from pytmx.collider import Collider
+
+
+class TestCollider(unittest.TestCase):
+
+    def test_rectangle_center(self):
+        collider = Collider(x=10, y=20, width=30, height=40)
+        self.assertEqual(collider.get_center(), (25.0, 40.0))
+
+    def test_polygon_type(self):
+        collider = Collider(x=0, y=0, type="polygon", points=[(0, 0), (1, 1)])
+        self.assertTrue(collider.is_polygon())
+        self.assertFalse(collider.is_ellipse())
+        self.assertFalse(collider.is_point())
+
+    def test_ellipse_type(self):
+        collider = Collider(x=0, y=0, type="ellipse", width=10, height=10)
+        self.assertTrue(collider.is_ellipse())
+        self.assertFalse(collider.is_polygon())
+        self.assertFalse(collider.is_point())
+
+    def test_point_type(self):
+        collider = Collider(x=5, y=5, type="point")
+        self.assertTrue(collider.is_point())
+        self.assertFalse(collider.is_polygon())
+        self.assertFalse(collider.is_ellipse())
+
+    def test_custom_properties(self):
+        collider = Collider(x=0, y=0, properties={"solid": True, "damage": 10})
+        self.assertTrue(collider.get_property("solid"))
+        self.assertEqual(collider.get_property("damage"), 10)
+        self.assertIsNone(collider.get_property("nonexistent"))
+        self.assertEqual(collider.get_property("nonexistent", "default"), "default")


### PR DESCRIPTION
PR introduces a new `Collider` dataclass to represent tile-level collision shapes. This makes it easier to work with rectangles, polygons, ellipses, and points directly from Tiled maps.

Here’s what’s been added:
- `Collider` class with fields for position, size, shape type, rotation, optional polygon points and custom properties
- helper methods like `get_center()` and type checks (`is_polygon()`, `is_ellipse()`, `is_point()`) to simplify downstream usage
- extended the `parse_all_tiles` method in `TiledTileset` to extract `<objectgroup>` data from tiles and convert them into collider dictionaries, the parser now handles rectangles, polygons, ellipses, and points, and stores them under `props["colliders"]` for each tile
- updated `get_tile_colliders()` to yield `(gid, [Collider, ...])` pairs based on the parsed data

This lays the groundwork for more robust collision handling and opens the door for physics integration, hitbox rendering, and custom gameplay logic tied to tile shapes (started with #29)